### PR TITLE
Some performance enhancements

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@
 .Rhistory
 .RData
 inst/doc
+/tryout.R

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -21,4 +21,4 @@ Suggests:
     testthat,
     knitr
 VignetteBuilder: knitr
-RoxygenNote: 5.0.0
+RoxygenNote: 5.0.1

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -9,7 +9,7 @@ Description: Two global-value-chain decompositions are implemented. Firstly, the
     International Production Sharing at the Bilateral and Sector Levels.").
 Authors@R: c( person("Bastiaan", "Quast", email = "bquast@gmail.com", role =
     c("aut", "cre") ), person("Fei", "Wang", role = "aut"), person("Victor",
-    "Kummritz", role = "aut") )
+    "Kummritz", role = "aut"), person("Oliver", "Reiter", role = "ctb") )
 Maintainer: Bastiaan Quast <bquast@gmail.com>
 Depends:
     R (>= 2.10)

--- a/R/decomp.R
+++ b/R/decomp.R
@@ -72,7 +72,11 @@ decomp <- function( x, y, k, i, o, V,
   In order to use the Wang-Wei-Zhu (cf. decompr v.1), please specify this explicitly using: method="wwz"')
   }
 
-  method <- match.arg(method)
+    method <- match.arg(method)
+
+    if(missing(V)) {
+        V <- NULL
+    }
 
   if ( missing(k) | missing(i) | missing(o) ) {
     warning('argument k, i, or o is missing, switching to the old "load_tables" function, which is DEPRECATED! Please see "help(decomp) and "http://qua.st/decompr/decompr-v2/" for more information on this.')

--- a/R/decomp.R
+++ b/R/decomp.R
@@ -16,6 +16,7 @@
 #' @param k vector or country or region names
 #' @param i vector of sector or industry names
 #' @param o vector of final outputs
+#' @param V vector of value added
 #' @param method user specified the decomposition method
 #' @param ... arguments to pass on the respective decomposition method
 #' @return The output when using the WWZ algorithm is a matrix with dimensions GNG*19.
@@ -62,7 +63,8 @@
 
 
 
-decomp <- function( x, y, k, i, o,  method=c("leontief", "wwz" ), ... ) {
+decomp <- function( x, y, k, i, o, V,
+                   method=c("leontief", "wwz" ), ... ) {
 
   if ( missing(method) ) {
     message('No method specified, the default method in version 2 of decompr has been changed to Leontief.
@@ -76,7 +78,7 @@ decomp <- function( x, y, k, i, o,  method=c("leontief", "wwz" ), ... ) {
     warning('argument k, i, or o is missing, switching to the old "load_tables" function, which is DEPRECATED! Please see "help(decomp) and "http://qua.st/decompr/decompr-v2/" for more information on this.')
     decompr_obj <- load_tables(x, y)
   }  else {
-    decompr_obj <- load_tables_vectors(x, y, k, i, o)
+    decompr_obj <- load_tables_vectors(x, y, k, i, o, V)
   }
 
   if ( method == "leontief" ) {

--- a/R/decomp.R
+++ b/R/decomp.R
@@ -16,7 +16,7 @@
 #' @param k vector or country or region names
 #' @param i vector of sector or industry names
 #' @param o vector of final outputs
-#' @param V vector of value added
+#' @param V vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption
 #' @param method user specified the decomposition method
 #' @param ... arguments to pass on the respective decomposition method
 #' @return The output when using the WWZ algorithm is a matrix with dimensions GNG*19.

--- a/R/decomp.R
+++ b/R/decomp.R
@@ -16,7 +16,7 @@
 #' @param k vector or country or region names
 #' @param i vector of sector or industry names
 #' @param o vector of final outputs
-#' @param V vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption
+#' @param v vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption
 #' @param method user specified the decomposition method
 #' @param verbose logical, should timings of the calculation be displayed? Default is FALSE
 #' @param ... arguments to pass on the respective decomposition method

--- a/R/decomp.R
+++ b/R/decomp.R
@@ -18,6 +18,7 @@
 #' @param o vector of final outputs
 #' @param V vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption
 #' @param method user specified the decomposition method
+#' @param verbose logical, should timings of the calculation be displayed? Default is FALSE
 #' @param ... arguments to pass on the respective decomposition method
 #' @return The output when using the WWZ algorithm is a matrix with dimensions GNG*19.
 #'  Whereby 19 is the 16 objects the WWZ algorithm decomposes exports into, plus three checksums.
@@ -63,8 +64,10 @@
 
 
 
-decomp <- function( x, y, k, i, o, V,
-                   method=c("leontief", "wwz" ), ... ) {
+decomp <- function(x, y, k, i, o, v,
+                   method=c("leontief", "wwz" ),
+                   verbose = FALSE,
+                   ... ) {
 
   if ( missing(method) ) {
     message('No method specified, the default method in version 2 of decompr has been changed to Leontief.
@@ -74,21 +77,21 @@ decomp <- function( x, y, k, i, o, V,
 
     method <- match.arg(method)
 
-    if(missing(V)) {
-        V <- NULL
+    if(missing(v)) {
+        v <- NULL
     }
 
   if ( missing(k) | missing(i) | missing(o) ) {
     warning('argument k, i, or o is missing, switching to the old "load_tables" function, which is DEPRECATED! Please see "help(decomp) and "http://qua.st/decompr/decompr-v2/" for more information on this.')
     decompr_obj <- load_tables(x, y)
   }  else {
-    decompr_obj <- load_tables_vectors(x, y, k, i, o, V)
+      decompr_obj <- load_tables_vectors(x, y, k, i, o, v)
   }
 
   if ( method == "leontief" ) {
-    out <- leontief( decompr_obj, ... )
+      out <- leontief(decompr_obj, ... )
   } else if (method == "wwz" ) {
-    out <- wwz(     decompr_obj )
+      out <- wwz(decompr_obj, verbose = verbose)
   } else {
     stop('not a valid method')
   }

--- a/R/leontief.R
+++ b/R/leontief.R
@@ -10,17 +10,17 @@
 #' No. w19677. National Bureau of Economic Research, 2013.
 #' @export
 #' @examples
-#' # load example data
+#'## load example data
 #' data(leather)
 #' 
-#' # create intermediate object (class decompr)
+#'## create intermediate object (class decompr)
 #' decompr_object <- load_tables_vectors(inter,
 #'                                       final,
 #'                                       countries,
 #'                                       industries,
 #'                                       out        )
 #'
-#' # run the Leontief decomposition on the decompr object
+#'## run the Leontief decomposition on the decompr object
 #' leontief(decompr_object )
 
 
@@ -28,75 +28,82 @@ leontief <- function(x,
                      post = c("exports", "output", "final_demand", "none"),
                      long=TRUE ) {
 
-  post <- match.arg(post)
+    post <- match.arg(post)
 
-  # compute Leontief inverse
-  out <- x$Vhat %*% x$B
+    ## compute Leontief inverse
+    ## out <- x$Vhat %*% x$B
+    V <- x$Vc * x$B
 
-  # post multiply
-  if (post == "exports") {
-    out <- out %*% x$Exp
-  } else if (post == "output") {
-    out <- out %*% diag(x$X)
-  } else if (post == "final_demand") {
+    ## post multiply
+    if (post == "exports") {
+        ## out.old <- V %*% diag(rowSums(x$ESR))
+        out <- sweep(V, 2, rowSums(x$ESR), `*`)
+        ## sum(abs(out.old - out))
 
-    out <- out %*% x$Y
+    } else if (post == "output") {
+        ## out <- V %*% diag(x$X)
+        out <- sweep(V, 2, x$X, `*`)
+        
+    } else if (post == "final_demand") {
 
-    # create output format for post="final_demand"
-    out <- as.vector(t(out))
-    out <- data.frame( rep(x$k, each=x$GN),
-                       rep(x$i, times=x$G, each=x$G),
-                       rep(x$k, times=x$GN),
-                       out
-                       )
-      names(out) <- c("Source_Country", "Source_Industry",
-                      "Importing_Country", "Final_Demand")
+        ## out <- V %*% x$Y
+        out <- sweep(V, 2, x$Y, `*`)
 
-    # create attributes
+        ## create output format for post="final_demand"
+        out <- as.vector(t(out))
+        out <- data.frame(rep(x$k, each=x$GN),
+                          rep(x$i, times=x$G, each=x$G),
+                          rep(x$k, times=x$GN),
+                          out
+                          )
+        names(out) <- c("Source_Country", "Source_Industry",
+                        "Importing_Country", "Final_Demand")
+
+        ## create attributes
+        attr(out, "k")      <- x$k
+        attr(out, "i")      <- x$i
+        attr(out, "decomposition") <- "leontief"
+
+        return(out)
+    }
+
+
+
+    ## structure output format
+    if (long == TRUE) {
+
+        out <- as.vector(t(out))
+        out <- data.frame( rep(x$k,                  each = x$GN*x$N ),
+                          rep(x$i, times = x$G,     each = x$GN),
+                          rep(x$k, times = x$GN,    each = x$N),
+                          rep(x$i, times = x$GN*x$G ),
+                          out)
+        names(out) <- c("Source_Country", "Source_Industry", "Using_Country", "Using_Industry", "FVAX")
+
+        ## set long attribute to TRUE
+        attr(out, "long") <- TRUE
+
+    } else {
+
+        ## add row and column names
+        out <- as.data.frame(out)
+        if (post != "final_demand") names(out) <- x$rownam
+        row.names(out) <- x$rownam
+
+        ## set long attribute to FALSE
+        attr(out, "long") <- FALSE
+
+    }
+
+
+
+    ## create attributes
     attr(out, "k")      <- x$k
     attr(out, "i")      <- x$i
     attr(out, "decomposition") <- "leontief"
+    ## attr(out, "rownam") <- x$rownam
 
-    return(out)
-  }
-
-
-
-  # structure output format
-  if (long == TRUE) {
-
-    out <- as.vector(t(out))
-    out <- data.frame( rep(x$k,                  each = x$GN*x$N ),
-                       rep(x$i, times = x$G,     each = x$GN),
-                       rep(x$k, times = x$GN,    each = x$N),
-                       rep(x$i, times = x$GN*x$G ),
-                       out)
-    names(out) <- c("Source_Country", "Source_Industry", "Using_Country", "Using_Industry", "FVAX")
-
-    # set long attribute to TRUE
-    attr(out, "long") <- TRUE
-
-  } else {
-
-    # add row and column names
-    out <- as.data.frame(out)
-    if (post != "final_demand") names(out) <- x$rownam
-    row.names(out) <- x$rownam
-
-    # set long attribute to FALSE
-    attr(out, "long") <- FALSE
-
-  }
-
-
-
-  # create attributes
-  attr(out, "k")      <- x$k
-  attr(out, "i")      <- x$i
-  attr(out, "decomposition") <- "leontief"
-  # attr(out, "rownam") <- x$rownam
-
-  # return result
-  return( out )
+    ## return result
+    return( out )
 
 }

--- a/R/leontief.R
+++ b/R/leontief.R
@@ -24,7 +24,9 @@
 #' leontief(decompr_object )
 
 
-leontief <- function( x, post = c("exports", "output", "final_demand", "none"), long=TRUE ) {
+leontief <- function(x,
+                     post = c("exports", "output", "final_demand", "none"),
+                     long=TRUE ) {
 
   post <- match.arg(post)
 
@@ -47,7 +49,8 @@ leontief <- function( x, post = c("exports", "output", "final_demand", "none"), 
                        rep(x$k, times=x$GN),
                        out
                        )
-    names(out) <- c("Source_Country", "Source_Industry", "Importing_Country", "Final_Demand")
+      names(out) <- c("Source_Country", "Source_Industry",
+                      "Importing_Country", "Final_Demand")
 
     # create attributes
     attr(out, "k")      <- x$k

--- a/R/load_tables_vectors.R
+++ b/R/load_tables_vectors.R
@@ -36,87 +36,85 @@
 #' str(decompr_object)
 
 
-load_tables_vectors <- function(x, y, k, i, o, V,
-                                null_inventory = FALSE ) {
-
-    ## find number of sections and regions
-    ## compute combination
-    G      <- length(k)
-    N      <- length(i)
-    GN     <- G * N  
+load_tables_vectors <- function(x, y, k, i, o, V, null_inventory = FALSE) {
+    
+    ## find number of sections and regions compute combination
+    G <- length(k)
+    N <- length(i)
+    GN <- G * N
     
     ## create vector of unique combinations of regions and sectors
-    z <- t(outer(k, i, paste, sep="."))
+    z <- t(outer(k, i, paste, sep = "."))
     rownam <- as.vector(z)
     
     ## making the big rownames: bigrownam
-    z01 <-  t(matrix( rownam, nrow=GN, ncol=G ) )
-    dim(z01 ) <- c( (G)*GN,1 )
-    z02 <- rep( k,times=GN )
+    z01 <- t(matrix(rownam, nrow = GN, ncol = G))
+    dim(z01) <- c((G) * GN, 1)
+    z02 <- rep(k, times = GN)
     
-    bigrownam <- paste( z01, z02, sep="." )
+    bigrownam <- paste(z01, z02, sep = ".")
     
     ## contruct final demand components
-    fdc <- dim(y)[2] / G
+    fdc <- dim(y)[2]/G
     
     ## null inventory if needed
-    if (null_inventory==TRUE) {
-        y[ , fdc*(1:G) ] <- 0
+    if (null_inventory == TRUE) {
+        y[, fdc * (1:G)] <- 0
     }
     
     ## define dimensions
-    Ad   <- matrix( 0, nrow = GN, ncol = GN )
-    Am   <- Ad
-    Bd   <- Ad
-    Bm   <- Ad
-    Y    <- matrix( 0, nrow = GN, ncol = G )
-    Yd   <- Y
-    Ym   <- Y
-    ESR  <- Y
+    Ad <- matrix(0, nrow = GN, ncol = GN)
+    Am <- Ad
+    Bd <- Ad
+    Bm <- Ad
+    Y <- matrix(0, nrow = GN, ncol = G)
+    Yd <- Y
+    Ym <- Y
+    ESR <- Y
     Eint <- Y
-    Efd  <- Y
+    Efd <- Y
     
     X <- o
     
     ## this might not be the best way to construct V
-    if(is.null(V)) {
-        V <- o - colSums( x )
+    if (is.null(V)) {
+        V <- o - colSums(x)
     }
     
     A <- t(t(x)/o)
-    A[ is.na( A ) ] <- 0
-    A[ A==Inf ] <- 0
+    A[is.na(A)] <- 0
+    A[A == Inf] <- 0
     II <- diag(GN)
-    B <- solve( II-A )
+    B <- solve(II - A)
     Bm <- B
     Am <- A
     
-    for (j in 1:G )  {
-        m=1+(j-1)*N
-        n=N+(j-1)*N
+    for (j in 1:G) {
+        m = 1 + (j - 1) * N
+        n = N + (j - 1) * N
         
-        Ad[m:n,m:n]  <- A[m:n,m:n]
-        Bd[m:n,m:n]  <- B[m:n,m:n]
-        Bm[m:n,m:n]  <- 0
-        Am[m:n,m:n]  <- 0
+        Ad[m:n, m:n] <- A[m:n, m:n]
+        Bd[m:n, m:n] <- B[m:n, m:n]
+        Bm[m:n, m:n] <- 0
+        Am[m:n, m:n] <- 0
     }
     
-    L                 <- solve( II-Ad )
-    Vc                <- V/o
-    Vc[ is.na( Vc ) ] <- 0
-    Vc[ Vc==Inf ]     <- 0
+    L <- solve(II - Ad)
+    Vc <- V/o
+    Vc[is.na(Vc)] <- 0
+    Vc[Vc == Inf] <- 0
     
     Vhat <- diag(Vc)
     
     ## Part 2: computing final demand: Y
-    for ( j in 1:G ){
-        m <- 1   + (j-1) * fdc
-        n <- fdc + (j-1) * fdc
+    for (j in 1:G) {
+        m <- 1 + (j - 1) * fdc
+        n <- fdc + (j - 1) * fdc
         
         if (m == n) {
-            Y[ , j ] <- y[ , m:n ]
+            Y[, j] <- y[, m:n]
         } else {
-            Y[ , j ] <- rowSums( y[ , m:n ] )
+            Y[, j] <- rowSums(y[, m:n])
         }
     }
     
@@ -124,102 +122,77 @@ load_tables_vectors <- function(x, y, k, i, o, V,
     
     
     ## Part 3: computing export: E, Esr
-    E <- cbind( x, y )
+    E <- cbind(x, y)
     
-    for (j in 1:G )  {
-        m <- 1 +(j-1)*N
-        n <- N +(j-1)*N
+    for (j in 1:G) {
+        m <- 1 + (j - 1) * N
+        n <- N + (j - 1) * N
         
-        E[m:n, m:n]  <- 0## intermediate demand for domestic goods
+        E[m:n, m:n] <- 0  ## intermediate demand for domestic goods
     }
     
-    for (j in 1:G)  {
-        m <- 1 + (j-1) * N
-        n <- N + (j-1) * N
+    for (j in 1:G) {
+        m <- 1 + (j - 1) * N
+        n <- N + (j - 1) * N
         
-        s <- GN + 1   + (j-1) * fdc
-        r <- GN + fdc + (j-1) * fdc
+        s <- GN + 1 + (j - 1) * fdc
+        r <- GN + fdc + (j - 1) * fdc
         
-        E[m:n,s:r]  <- 0## final demand for domestic goods
-        Yd[ m:n,j ] <- Y[m:n,j]
-        Ym[ m:n,j ] <- 0
+        E[m:n, s:r] <- 0  ## final demand for domestic goods
+        Yd[m:n, j] <- Y[m:n, j]
+        Ym[m:n, j] <- 0
     }
     
     z <- E
-    E <- rowSums( E )
-    E <- as.matrix( E )
+    E <- rowSums(E)
+    E <- as.matrix(E)
     
-    for (j in 1:G)  {
-        m <- 1        + (j-1) * N
-        n <- N        + (j-1) * N
-        s <- GN + 1   + (j-1) * fdc
-        r <- GN + fdc + (j-1) * fdc
+    for (j in 1:G) {
+        m <- 1 + (j - 1) * N
+        n <- N + (j - 1) * N
+        s <- GN + 1 + (j - 1) * fdc
+        r <- GN + fdc + (j - 1) * fdc
         if (s == r) {
-            fge <- z[ ,s:r ]
+            fge <- z[, s:r]
         } else {
-            fge <- rowSums( z[ ,s:r ] )
+            fge <- rowSums(z[, s:r])
         }
-        ESR[ ,j ]  <- rowSums( z[ , m:n ] ) + fge
-        Eint[ ,j ] <- rowSums( z[ , m:n ] )
-        Efd[ ,j ]  <- fge
+        ESR[, j] <- rowSums(z[, m:n]) + fge
+        Eint[, j] <- rowSums(z[, m:n])
+        Efd[, j] <- fge
     }
     
-    Exp <- diag( rowSums(ESR) )
+    Exp <- diag(rowSums(ESR))
     
     
     ## Part 4: naming the rows and columns in variables
-    colnames(A)     <- rownam
-    rownames(A)     <- rownam
-    A_names         <- dimnames(A)
-    dimnames(B)     <- A_names
-    dimnames(Bm)    <- A_names
-    dimnames(Bd)    <- A_names
-    dimnames(Ad)    <- A_names
-    dimnames(Am)    <- A_names
-    dimnames(L)     <- A_names
-    names(Vc)       <- rownam
-    names(o)        <- rownam
-    colnames(Y)     <- k
-    rownames( Y )   <- rownam
-    dimnames(Ym)    <- dimnames( Y )
-    names(E)        <- rownam
-    colnames(ESR)   <- k
-    rownames( ESR ) <- rownam
-    dimnames(Eint)  <- dimnames( ESR )
-    dimnames(Efd)   <- dimnames( ESR )
-
+    colnames(A) <- rownam
+    rownames(A) <- rownam
+    A_names <- dimnames(A)
+    dimnames(B) <- A_names
+    dimnames(Bm) <- A_names
+    dimnames(Bd) <- A_names
+    dimnames(Ad) <- A_names
+    dimnames(Am) <- A_names
+    dimnames(L) <- A_names
+    names(Vc) <- rownam
+    names(o) <- rownam
+    colnames(Y) <- k
+    rownames(Y) <- rownam
+    dimnames(Ym) <- dimnames(Y)
+    names(E) <- rownam
+    colnames(ESR) <- k
+    rownames(ESR) <- rownam
+    dimnames(Eint) <- dimnames(ESR)
+    dimnames(Efd) <- dimnames(ESR)
+    
     
     ## Part 5: creating decompr object
-    out <- list( Exp  = Exp,
-                Vhat = Vhat,
-                A    = A,
-                Ad   = Ad,
-                Am   = Am,
-                B    = B,
-                Bd   = Bd,
-                Bm   = Bm,
-                bigrownam = bigrownam,
-                E    = E,
-                ESR  = ESR,
-                Eint = Eint,
-                Efd  = Efd,
-                fdc  = fdc,
-                G    = G,
-                GN   = GN,
-                i    = i,
-                k    = k,
-                L    = L,
-                N    = N,
-                rownam = rownam,
-                Vc   = Vc,
-                X    = o,
-                Y    = Y,
-                Yd   = Yd,
-                Ym   = Ym,
-                z    = z,
-                z01  = z01,
-                z02  = z02
-                )
+    out <- list(Exp = Exp, Vhat = Vhat, A = A, Ad = Ad, Am = Am, B = B, 
+        Bd = Bd, Bm = Bm, bigrownam = bigrownam, E = E, ESR = ESR, 
+        Eint = Eint, Efd = Efd, fdc = fdc, G = G, GN = GN, i = i, 
+        k = k, L = L, N = N, rownam = rownam, Vc = Vc, X = o, Y = Y, 
+        Yd = Yd, Ym = Ym, z = z, z01 = z01, z02 = z02)
     
     class(out) <- "decompr"
     

--- a/R/load_tables_vectors.R
+++ b/R/load_tables_vectors.R
@@ -15,6 +15,7 @@
 #' @param k vector or country or region names
 #' @param i vector of sector or industry names
 #' @param o vector of final outputs
+#' @param V vector of value added
 #' @param null_inventory when the inventory (last FDC) should be set to zero
 #' @return a decompr class object
 #' @author Bastiaan Quast
@@ -35,7 +36,8 @@
 #' str(decompr_object)
 
 
-load_tables_vectors <- function(x, y, k, i, o, null_inventory = FALSE ) {
+load_tables_vectors <- function(x, y, k, i, o, V,
+                                null_inventory = FALSE ) {
 
   # find number of sections and regions
   # compute combination
@@ -76,8 +78,9 @@ load_tables_vectors <- function(x, y, k, i, o, null_inventory = FALSE ) {
   
   X <- o
   
-  #### this might not be the best way to construct V
-  V <- o - colSums( x )
+  ## this might not be the best way to construct V
+    ## V <- o - colSums( x )
+    ## use separate argument
   
   A <- t(t(x)/o)
   A[ is.na( A ) ] <- 0

--- a/R/load_tables_vectors.R
+++ b/R/load_tables_vectors.R
@@ -44,15 +44,13 @@ load_tables_vectors <- function(x, y, k, i, o, V, null_inventory = FALSE) {
     GN <- G * N
     
     ## create vector of unique combinations of regions and sectors
-    z <- t(outer(k, i, paste, sep = "."))
-    rownam <- as.vector(z)
+    rownam <- as.vector(t(outer(k, i, paste, sep = ".")))
     
     ## making the big rownames: bigrownam
-    z01 <- t(matrix(rownam, nrow = GN, ncol = G))
-    dim(z01) <- c((G) * GN, 1)
-    z02 <- rep(k, times = GN)
-    
-    bigrownam <- paste(z01, z02, sep = ".")
+    ## z01 <- t(matrix(rownam, nrow = GN, ncol = G))
+    ## dim(z01) <- c((G) * GN, 1)
+    ## z02 <- rep(k, times = GN)
+    ## bigrownam <- paste(z01, z02, sep = ".")
     
     ## contruct final demand components
     fdc <- dim(y)[2]/G
@@ -63,74 +61,62 @@ load_tables_vectors <- function(x, y, k, i, o, V, null_inventory = FALSE) {
     }
     
     ## define dimensions
-    Ad <- matrix(0, nrow = GN, ncol = GN)
-    Am <- Ad
-    Bd <- Ad
-    Bm <- Ad
-    Y <- matrix(0, nrow = GN, ncol = G)
-    Yd <- Y
-    Ym <- Y
-    ESR <- Y
-    Eint <- Y
-    Efd <- Y
-    
-    X <- o
+    ## -> only needed for matrizes that will be "manually"
+    ## (e.g. in a for-loop) filled
+    ## For matrix copies, no need for setting the dimensions,
+    ## only increases the memory burden
+    Bd <- Ad <- matrix(0, nrow = GN, ncol = GN)
+    Yd <- ESR <- Eint <- Efd <- Y <- matrix(0, nrow = GN, ncol = G)
+
     
     ## this might not be the best way to construct V
     if (is.null(V)) {
         V <- o - colSums(x)
     }
     
-    A <- t(t(x)/o)
-    A[is.na(A)] <- 0
-    A[A == Inf] <- 0
-    II <- diag(GN)
-    B <- solve(II - A)
-    Bm <- B
+    A <- t(t(x) / o)
+    A[!is.finite(A)] <- 0
     Am <- A
+
+    II <- diag(GN)
+    Bm <- B <- solve(II - A)
     
     for (j in 1:G) {
         m = 1 + (j - 1) * N
         n = N + (j - 1) * N
-        
+
+        ## set diagonal
         Ad[m:n, m:n] <- A[m:n, m:n]
         Bd[m:n, m:n] <- B[m:n, m:n]
+
+        ## delete diagonal
         Bm[m:n, m:n] <- 0
         Am[m:n, m:n] <- 0
     }
     
     L <- solve(II - Ad)
     Vc <- V/o
-    Vc[is.na(Vc)] <- 0
-    Vc[Vc == Inf] <- 0
-    
-    Vhat <- diag(Vc)
+    Vc[!is.finite(Vc)] <- 0
+    ## Vhat <- diag(Vc)
     
     ## Part 2: computing final demand: Y
-    for (j in 1:G) {
-        m <- 1 + (j - 1) * fdc
-        n <- fdc + (j - 1) * fdc
-        
-        if (m == n) {
-            Y[, j] <- y[, m:n]
-        } else {
+    if(fdc > 1) {
+        for (j in 1:G) {
+            m <- 1 + (j - 1) * fdc
+            n <- fdc + (j - 1) * fdc
+
             Y[, j] <- rowSums(y[, m:n])
         }
+    } else if(fdc == 1) {
+        Y <- y
     }
-    
+
+    ## domestic final demand
     Ym <- Y
     
     
     ## Part 3: computing export: E, Esr
     E <- cbind(x, y)
-    
-    for (j in 1:G) {
-        m <- 1 + (j - 1) * N
-        n <- N + (j - 1) * N
-        
-        E[m:n, m:n] <- 0  ## intermediate demand for domestic goods
-    }
-    
     for (j in 1:G) {
         m <- 1 + (j - 1) * N
         n <- N + (j - 1) * N
@@ -138,61 +124,93 @@ load_tables_vectors <- function(x, y, k, i, o, V, null_inventory = FALSE) {
         s <- GN + 1 + (j - 1) * fdc
         r <- GN + fdc + (j - 1) * fdc
         
+        E[m:n, m:n] <- 0  ## intermediate demand for domestic goods
         E[m:n, s:r] <- 0  ## final demand for domestic goods
+
         Yd[m:n, j] <- Y[m:n, j]
         Ym[m:n, j] <- 0
     }
     
     z <- E
-    E <- rowSums(E)
-    E <- as.matrix(E)
-    
+    E <- as.matrix(rowSums(E))
+
     for (j in 1:G) {
         m <- 1 + (j - 1) * N
         n <- N + (j - 1) * N
         s <- GN + 1 + (j - 1) * fdc
         r <- GN + fdc + (j - 1) * fdc
+
+        ## Final goods exports
         if (s == r) {
-            fge <- z[, s:r]
+            Efd[, j] <- z[, s:r]
         } else {
-            fge <- rowSums(z[, s:r])
+            Efd[, j] <- rowSums(z[, s:r])
         }
-        ESR[, j] <- rowSums(z[, m:n]) + fge
+
+        ## Total exports
+        ESR[, j] <- rowSums(z[, m:n]) + Efd[, j]
+
+        ## intermediate exports
         Eint[, j] <- rowSums(z[, m:n])
-        Efd[, j] <- fge
     }
-    
-    Exp <- diag(rowSums(ESR))
     
     
     ## Part 4: naming the rows and columns in variables
-    colnames(A) <- rownam
-    rownames(A) <- rownam
-    A_names <- dimnames(A)
-    dimnames(B) <- A_names
-    dimnames(Bm) <- A_names
-    dimnames(Bd) <- A_names
-    dimnames(Ad) <- A_names
-    dimnames(Am) <- A_names
-    dimnames(L) <- A_names
+    ## colnames(A) <- rownam
+    ## rownames(A) <- rownam
     names(Vc) <- rownam
     names(o) <- rownam
-    colnames(Y) <- k
     rownames(Y) <- rownam
-    dimnames(Ym) <- dimnames(Y)
-    names(E) <- rownam
-    colnames(ESR) <- k
     rownames(ESR) <- rownam
+    names(E) <- rownam
+
+    dimnames(B) <- dimnames(A)
+    dimnames(Bm) <- dimnames(A)
+    dimnames(Bd) <- dimnames(A)
+    ## dimnames(Ad) <- dimnames(A)
+    dimnames(Am) <- dimnames(A)
+    dimnames(L) <- dimnames(A)
+    
+    colnames(ESR) <- k
+    colnames(Y) <- k
+    
+    dimnames(Ym) <- dimnames(Y)
+    
     dimnames(Eint) <- dimnames(ESR)
     dimnames(Efd) <- dimnames(ESR)
-    
+
     
     ## Part 5: creating decompr object
-    out <- list(Exp = Exp, Vhat = Vhat, A = A, Ad = Ad, Am = Am, B = B, 
-        Bd = Bd, Bm = Bm, bigrownam = bigrownam, E = E, ESR = ESR, 
-        Eint = Eint, Efd = Efd, fdc = fdc, G = G, GN = GN, i = i, 
-        k = k, L = L, N = N, rownam = rownam, Vc = Vc, X = o, Y = Y, 
-        Yd = Yd, Ym = Ym, z = z, z01 = z01, z02 = z02)
+    out <- list(Am = Am,
+                ## Ad = Ad, ## never used
+                ## A = A, ## never used
+                B = B,                  # leontief
+                Bd = Bd,                # wwz
+                Bm = Bm,                # wwz
+                L = L,
+                E = E,
+                ESR = ESR,
+                Eint = Eint,
+                Efd = Efd,
+                Vc = Vc,
+                ## fdc = fdc, ## never used
+
+                ## country/industry parameter
+                G = G,
+                GN = GN,
+                i = i, 
+                k = k,
+                N = N,
+                
+                rownam = rownam,
+                ## bigrownam = bigrownam,
+                ## Vhat = Vhat,
+                X = o,                  # leontief
+                Y = Y,                  # leontief
+                Yd = Yd,
+                Ym = Ym)
+    ## z = z,
+    ## z01 = z01, z02 = z02)
     
     class(out) <- "decompr"
     

--- a/R/load_tables_vectors.R
+++ b/R/load_tables_vectors.R
@@ -39,190 +39,191 @@
 load_tables_vectors <- function(x, y, k, i, o, V,
                                 null_inventory = FALSE ) {
 
-  # find number of sections and regions
-  # compute combination
-  G      <- length(k)
-  N      <- length(i)
-  GN     <- G * N  
-  
-  # create vector of unique combinations of regions and sectors
-  z <- t(outer(k, i, paste, sep="."))
-  rownam <- as.vector(z)
-  
-  # making the big rownames: bigrownam
-  z01 <-  t(matrix( rownam, nrow=GN, ncol=G ) )
-  dim(z01 ) <- c( (G)*GN,1 )
-  z02 <- rep( k,times=GN )
-  
-  bigrownam <- paste( z01, z02, sep="." )
-  
-    # contruct final demand components
-  fdc <- dim(y)[2] / G
-  
-  # null inventory if needed
-  if (null_inventory==TRUE) {
-    y[ , fdc*(1:G) ] <- 0
-  }
-  
-  # define dimensions
-  Ad   <- matrix( 0, nrow = GN, ncol = GN )
-  Am   <- Ad
-  Bd   <- Ad
-  Bm   <- Ad
-  Y    <- matrix( 0, nrow = GN, ncol = G )
-  Yd   <- Y
-  Ym   <- Y
-  ESR  <- Y
-  Eint <- Y
-  Efd  <- Y
-  
-  X <- o
-  
-  ## this might not be the best way to construct V
-    ## V <- o - colSums( x )
-    ## use separate argument
-  
-  A <- t(t(x)/o)
-  A[ is.na( A ) ] <- 0
-  A[ A==Inf ] <- 0
-  II <- diag(GN)
-  B <- solve( II-A )
-  Bm <- B
-  Am <- A
-  
-  for (j in 1:G )  {
-    m=1+(j-1)*N
-    n=N+(j-1)*N
+    ## find number of sections and regions
+    ## compute combination
+    G      <- length(k)
+    N      <- length(i)
+    GN     <- G * N  
     
-    Ad[m:n,m:n]  <- A[m:n,m:n]
-    Bd[m:n,m:n]  <- B[m:n,m:n]
-    Bm[m:n,m:n]  <- 0
-    Am[m:n,m:n]  <- 0
-  }
-  
-  L                 <- solve( II-Ad )
-  Vc                <- V/o
-  Vc[ is.na( Vc ) ] <- 0
-  Vc[ Vc==Inf ]     <- 0
-  
-  Vhat <- diag(Vc)
-  
-  # Part 2: computing final demand: Y
-  for ( j in 1:G ){
-    m <- 1   + (j-1) * fdc
-    n <- fdc + (j-1) * fdc
+    ## create vector of unique combinations of regions and sectors
+    z <- t(outer(k, i, paste, sep="."))
+    rownam <- as.vector(z)
     
-    if (m == n) {
-      Y[ , j ] <- y[ , m:n ]
-    } else {
-      Y[ , j ] <- rowSums( y[ , m:n ] )
+    ## making the big rownames: bigrownam
+    z01 <-  t(matrix( rownam, nrow=GN, ncol=G ) )
+    dim(z01 ) <- c( (G)*GN,1 )
+    z02 <- rep( k,times=GN )
+    
+    bigrownam <- paste( z01, z02, sep="." )
+    
+    ## contruct final demand components
+    fdc <- dim(y)[2] / G
+    
+    ## null inventory if needed
+    if (null_inventory==TRUE) {
+        y[ , fdc*(1:G) ] <- 0
     }
-  }
-  
-  Ym <- Y
-  
-  
-  # Part 3: computing export: E, Esr
-  E <- cbind( x, y )
-  
-  for (j in 1:G )  {
-    m <- 1 +(j-1)*N
-    n <- N +(j-1)*N
     
-    E[m:n, m:n]  <- 0   # intermediate demand for domestic goods
-  }
-  
-  for (j in 1:G)  {
-    m <- 1 + (j-1) * N
-    n <- N + (j-1) * N
+    ## define dimensions
+    Ad   <- matrix( 0, nrow = GN, ncol = GN )
+    Am   <- Ad
+    Bd   <- Ad
+    Bm   <- Ad
+    Y    <- matrix( 0, nrow = GN, ncol = G )
+    Yd   <- Y
+    Ym   <- Y
+    ESR  <- Y
+    Eint <- Y
+    Efd  <- Y
     
-    s <- GN + 1   + (j-1) * fdc
-    r <- GN + fdc + (j-1) * fdc
+    X <- o
     
-    E[m:n,s:r]  <- 0 # final demand for domestic goods
-    Yd[ m:n,j ] <- Y[m:n,j]
-    Ym[ m:n,j ] <- 0
-  }
-  
-  z <- E
-  E <- rowSums( E )
-  E <- as.matrix( E )
-  
-  for (j in 1:G)  {
-    m <- 1        + (j-1) * N
-    n <- N        + (j-1) * N
-    s <- GN + 1   + (j-1) * fdc
-    r <- GN + fdc + (j-1) * fdc
-    if (s == r) {
-      fge <- z[ ,s:r ]
-    } else {
-      fge <- rowSums( z[ ,s:r ] )
+    ## this might not be the best way to construct V
+    if(is.null(V)) {
+        V <- o - colSums( x )
     }
-    ESR[ ,j ]  <- rowSums( z[ , m:n ] ) + fge
-    Eint[ ,j ] <- rowSums( z[ , m:n ] )
-    Efd[ ,j ]  <- fge
-  }
-  
-  Exp <- diag( rowSums(ESR) )
-  
-  
-  # Part 4: naming the rows and columns in variables
-  colnames(A)     <- rownam
-  rownames(A)     <- rownam
-  A_names         <- dimnames(A)
-  dimnames(B)     <- A_names
-  dimnames(Bm)    <- A_names
-  dimnames(Bd)    <- A_names
-  dimnames(Ad)    <- A_names
-  dimnames(Am)    <- A_names
-  dimnames(L)     <- A_names
-  names(Vc)       <- rownam
-  names(o)        <- rownam
-  colnames(Y)     <- k
-  rownames( Y )   <- rownam
-  dimnames(Ym)    <- dimnames( Y )
-  names(E)        <- rownam
-  colnames(ESR)   <- k
-  rownames( ESR ) <- rownam
-  dimnames(Eint)  <- dimnames( ESR )
-  dimnames(Efd)   <- dimnames( ESR )
+    
+    A <- t(t(x)/o)
+    A[ is.na( A ) ] <- 0
+    A[ A==Inf ] <- 0
+    II <- diag(GN)
+    B <- solve( II-A )
+    Bm <- B
+    Am <- A
+    
+    for (j in 1:G )  {
+        m=1+(j-1)*N
+        n=N+(j-1)*N
+        
+        Ad[m:n,m:n]  <- A[m:n,m:n]
+        Bd[m:n,m:n]  <- B[m:n,m:n]
+        Bm[m:n,m:n]  <- 0
+        Am[m:n,m:n]  <- 0
+    }
+    
+    L                 <- solve( II-Ad )
+    Vc                <- V/o
+    Vc[ is.na( Vc ) ] <- 0
+    Vc[ Vc==Inf ]     <- 0
+    
+    Vhat <- diag(Vc)
+    
+    ## Part 2: computing final demand: Y
+    for ( j in 1:G ){
+        m <- 1   + (j-1) * fdc
+        n <- fdc + (j-1) * fdc
+        
+        if (m == n) {
+            Y[ , j ] <- y[ , m:n ]
+        } else {
+            Y[ , j ] <- rowSums( y[ , m:n ] )
+        }
+    }
+    
+    Ym <- Y
+    
+    
+    ## Part 3: computing export: E, Esr
+    E <- cbind( x, y )
+    
+    for (j in 1:G )  {
+        m <- 1 +(j-1)*N
+        n <- N +(j-1)*N
+        
+        E[m:n, m:n]  <- 0## intermediate demand for domestic goods
+    }
+    
+    for (j in 1:G)  {
+        m <- 1 + (j-1) * N
+        n <- N + (j-1) * N
+        
+        s <- GN + 1   + (j-1) * fdc
+        r <- GN + fdc + (j-1) * fdc
+        
+        E[m:n,s:r]  <- 0## final demand for domestic goods
+        Yd[ m:n,j ] <- Y[m:n,j]
+        Ym[ m:n,j ] <- 0
+    }
+    
+    z <- E
+    E <- rowSums( E )
+    E <- as.matrix( E )
+    
+    for (j in 1:G)  {
+        m <- 1        + (j-1) * N
+        n <- N        + (j-1) * N
+        s <- GN + 1   + (j-1) * fdc
+        r <- GN + fdc + (j-1) * fdc
+        if (s == r) {
+            fge <- z[ ,s:r ]
+        } else {
+            fge <- rowSums( z[ ,s:r ] )
+        }
+        ESR[ ,j ]  <- rowSums( z[ , m:n ] ) + fge
+        Eint[ ,j ] <- rowSums( z[ , m:n ] )
+        Efd[ ,j ]  <- fge
+    }
+    
+    Exp <- diag( rowSums(ESR) )
+    
+    
+    ## Part 4: naming the rows and columns in variables
+    colnames(A)     <- rownam
+    rownames(A)     <- rownam
+    A_names         <- dimnames(A)
+    dimnames(B)     <- A_names
+    dimnames(Bm)    <- A_names
+    dimnames(Bd)    <- A_names
+    dimnames(Ad)    <- A_names
+    dimnames(Am)    <- A_names
+    dimnames(L)     <- A_names
+    names(Vc)       <- rownam
+    names(o)        <- rownam
+    colnames(Y)     <- k
+    rownames( Y )   <- rownam
+    dimnames(Ym)    <- dimnames( Y )
+    names(E)        <- rownam
+    colnames(ESR)   <- k
+    rownames( ESR ) <- rownam
+    dimnames(Eint)  <- dimnames( ESR )
+    dimnames(Efd)   <- dimnames( ESR )
 
-  
-  # Part 5: creating decompr object
-  out <- list( Exp  = Exp,
-               Vhat = Vhat,
-               A    = A,
-               Ad   = Ad,
-               Am   = Am,
-               B    = B,
-               Bd   = Bd,
-               Bm   = Bm,
-               bigrownam = bigrownam,
-               E    = E,
-               ESR  = ESR,
-               Eint = Eint,
-               Efd  = Efd,
-               fdc  = fdc,
-               G    = G,
-               GN   = GN,
-               i    = i,
-               k    = k,
-               L    = L,
-               N    = N,
-               rownam = rownam,
-               Vc   = Vc,
-               X    = o,
-               Y    = Y,
-               Yd   = Yd,
-               Ym   = Ym,
-               z    = z,
-               z01  = z01,
-               z02  = z02
-               )
-  
-  class(out) <- "decompr"
-  
-  # Part 6: returning object
-  return(out)
-  
+    
+    ## Part 5: creating decompr object
+    out <- list( Exp  = Exp,
+                Vhat = Vhat,
+                A    = A,
+                Ad   = Ad,
+                Am   = Am,
+                B    = B,
+                Bd   = Bd,
+                Bm   = Bm,
+                bigrownam = bigrownam,
+                E    = E,
+                ESR  = ESR,
+                Eint = Eint,
+                Efd  = Efd,
+                fdc  = fdc,
+                G    = G,
+                GN   = GN,
+                i    = i,
+                k    = k,
+                L    = L,
+                N    = N,
+                rownam = rownam,
+                Vc   = Vc,
+                X    = o,
+                Y    = Y,
+                Yd   = Yd,
+                Ym   = Ym,
+                z    = z,
+                z01  = z01,
+                z02  = z02
+                )
+    
+    class(out) <- "decompr"
+    
+    ## Part 6: returning object
+    return(out)
+    
 }

--- a/R/load_tables_vectors.R
+++ b/R/load_tables_vectors.R
@@ -15,7 +15,7 @@
 #' @param k vector or country or region names
 #' @param i vector of sector or industry names
 #' @param o vector of final outputs
-#' @param V vector of value added
+#' @param v vector of value added
 #' @param null_inventory when the inventory (last FDC) should be set to zero
 #' @return a decompr class object
 #' @author Bastiaan Quast
@@ -30,13 +30,14 @@
 #'                                       final,
 #'                                       countries,
 #'                                       industries,
-#'                                       out        )
+#'                                       out)
 #' 
 #' # examine output object                                    
 #' str(decompr_object)
 
 
-load_tables_vectors <- function(x, y, k, i, o, V, null_inventory = FALSE) {
+load_tables_vectors <- function(x, y, k, i, o, v = NULL,
+                                null_inventory = FALSE) {
     
     ## find number of sections and regions compute combination
     G <- length(k)
@@ -70,8 +71,8 @@ load_tables_vectors <- function(x, y, k, i, o, V, null_inventory = FALSE) {
 
     
     ## this might not be the best way to construct V
-    if (is.null(V)) {
-        V <- o - colSums(x)
+    if (is.null(v)) {
+        v <- o - colSums(x)
     }
     
     A <- t(t(x) / o)
@@ -95,7 +96,7 @@ load_tables_vectors <- function(x, y, k, i, o, V, null_inventory = FALSE) {
     }
     
     L <- solve(II - Ad)
-    Vc <- V/o
+    Vc <- v/o
     Vc[!is.finite(Vc)] <- 0
     ## Vhat <- diag(Vc)
     

--- a/R/wwz.R
+++ b/R/wwz.R
@@ -3,6 +3,7 @@
 #' This function runs the Wang-Wei-Zhu decomposition.
 #' 
 #' @param x an object of the class decompr
+#' @param verbose logical, should timings of the calculation be displayed? Default is FALSE
 #' @return the decomposed table
 #' @author Bastiaan Quast
 #' @details Adapted from code by Fei Wang.
@@ -24,7 +25,7 @@
 #' # run the WWZ decomposition on the decompr object
 #' wwz(decompr_object)
 
-wwz <- function(x) {
+wwz <- function(x, verbose = FALSE) {
     
     ## Part 1: Decomposing Export into VA (16 items) defining ALL to
     ## contain all decomposed results
@@ -65,7 +66,10 @@ wwz <- function(x) {
     ## 
     ## DVA_FIN
     ##
-    start <- Sys.time()
+    if(verbose) {
+        message("Starting decomposing the trade flow ...")
+        start <- Sys.time()
+    }
 
     ## Term 1
     Bd_Vhat <- x$Bd * x$Vc
@@ -73,10 +77,11 @@ wwz <- function(x) {
         Ym.country <- x$Ym[, r]
         ALL[, r, 1] <- colSums(sweep(Bd_Vhat, 2, Ym.country, `*`))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("1/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("1/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }
     
     ## 
     ## DVA_INT
@@ -90,10 +95,11 @@ wwz <- function(x) {
     for (r in 1:x$G) {
         ALL[, r, 2] <- VsLss.colSums * t(Am_Bd_Yd[, r])
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("2/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("2/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }
 
 
 
@@ -123,10 +129,11 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 3] <- VsLss.colSums * (rowSums(z3[, m:n]))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("3/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-    
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("3/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }    
     
     ## Term 4
     z <- matrix(0, nrow = x$GN, ncol = x$GN)
@@ -144,10 +151,11 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 4] <- VsLss.colSums * (rowSums(z2[, m:n]))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("4/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-    
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("4/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }    
     
     ## Term 5
     z1 <- t(x$Bm %*% z)
@@ -163,10 +171,11 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 5] <- VsLss.colSums * (rowSums(z2[, m:n]))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("5/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("5/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }
     
 
     ##
@@ -189,10 +198,11 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 6] <- VsLss.colSums * (rowSums(z1[, m:n]))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("6/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-    
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("6/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }    
     
     ## Term 7
     z <- matrix(0, nrow = x$GN, ncol = x$GN)
@@ -208,10 +218,11 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 7] <- VsLss.colSums * (rowSums(z1[, m:n]))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("7/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("7/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }
     
     
     ## Term 8
@@ -228,10 +239,11 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 8] <- VsLss.colSums * (rowSums(z2[, m:n]))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("8/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-    
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("8/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }    
     
 
     ##
@@ -252,10 +264,11 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 13] <- VsLss.colSums * (rowSums(z1[, m:n]))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("9/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("9/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }
     
     ## Part 2-10 == H10-(10): DDC_INT
     Am_X <- t(t(x$Am) * x$X)
@@ -266,10 +279,11 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 14] <- Vc_Bd_VsLss.colsums * (rowSums(Am_X[, m:n]))
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("10/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-    
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("10/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }    
     ## Part 2-11 == H10-(11): MVA_FIN =[ VrBrs#Ysr ] H10-(14): OVA_FIN =[
     ## Sum(VtBts)#rYsr ] OK !
     ## VrBrs <- x$Vhat %*% x$Bm            # TODO
@@ -288,10 +302,11 @@ wwz <- function(x) {
         ALL[, r, 9] <- colSums(z[-c(m:n), ])  # OVA_FIN[ ,r ]
         ALL[, r, 10] <- colSums(z[m:n, ])  # MVA_FIN[ ,r ]
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("12/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("12/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }
     ## 
     ## MVA_FIN
     ## 
@@ -317,10 +332,11 @@ wwz <- function(x) {
         ALL[, r, 11] <- colSums(z[-c(m:n), ])  #   OVA_INT[ ,r ]
         ALL[, r, 12] <- colSums(z[m:n, ])  #  MVA_INT[ ,r ]
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("14/16, elapsed time: ", elapsed, " seconds")
-    start <- Sys.time()
-    
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("14/16, elapsed time: ", elapsed, " seconds")
+        start <- Sys.time()
+    }    
     ## Part 2-13 == H10-(13): MDC
     ## =[ VrBrs#AsrLrrEr* ] == H10-(16): ODC =[ Sum(VtBts)#AsrLrrEr* ] OK !
     for (r in 1:x$G) {
@@ -339,9 +355,10 @@ wwz <- function(x) {
         ALL[, r, 15] <- colSums(z[-c(m:n), ])  # ODC[ ,r ]
         ALL[, r, 16] <- colSums(z[m:n, ])  # MDC[ ,r ]
     }
-    elapsed <- round(Sys.time() - start, digits = 3)
-    message("16/16, elapsed time: ", elapsed, " seconds")
-
+    if(verbose) {
+        elapsed <- round(Sys.time() - start, digits = 3)
+        message("16/16, elapsed time: ", elapsed, " seconds")
+    }
     
     
     ## try to calculate DViX_Fsr

--- a/R/wwz.R
+++ b/R/wwz.R
@@ -54,15 +54,13 @@ wwz <- function(x) {
     ALL[, , 17] <- x$ESR
     ALL[, , 18] <- x$Eint
     ALL[, , 19] <- x$Efd
-    x$Eint <- NULL
-    x$Efd <- NULL
+    ## x$Eint <- NULL
+    ## x$Efd <- NULL
 
     
     ##
     ## all Terms are numbered as in Table A2 in the Appendix of WWZ
     ## 
-
-    Vhat.diag <- diag(x$Vhat)
 
     ## 
     ## DVA_FIN
@@ -70,7 +68,7 @@ wwz <- function(x) {
     start <- Sys.time()
 
     ## Term 1
-    Bd_Vhat <- x$Bd * Vhat.diag
+    Bd_Vhat <- x$Bd * x$Vc
     for (r in 1:x$G) {
         Ym.country <- x$Ym[, r]
         ALL[, r, 1] <- colSums(sweep(Bd_Vhat, 2, Ym.country, `*`))
@@ -85,7 +83,7 @@ wwz <- function(x) {
     ## 
 
     ## Term 2
-    VsLss <- Vhat.diag * x$L
+    VsLss <- x$Vc * x$L
     VsLss.colSums <- colSums(VsLss)
     Am_Bd_Yd <- x$Am %*% x$Bd %*% x$Yd
     
@@ -274,13 +272,19 @@ wwz <- function(x) {
     
     ## Part 2-11 == H10-(11): MVA_FIN =[ VrBrs#Ysr ] H10-(14): OVA_FIN =[
     ## Sum(VtBts)#rYsr ] OK !
-    VrBrs <- x$Vhat %*% x$Bm
+    ## VrBrs <- x$Vhat %*% x$Bm            # TODO
+    VrBrs <- x$Vc * x$Bm
     YYsr <- matrix(0, nrow = x$GN, ncol = x$GN)
     for (r in 1:x$G) {
         m <- 1 + (r - 1) * x$N
         n <- x$N + (r - 1) * x$N
-        YYsr[, 1:x$GN] <- x$Ym[, r]
-        z <- VrBrs * t(YYsr)
+
+        ## YYsr[, 1:x$GN] <- x$Ym[, r]
+        ## z <- VrBrs * t(YYsr)
+        ## just as fast, but more memory efficient
+        z <- sweep(VrBrs, 2, x$Ym[, r], `*`)
+        
+        
         ALL[, r, 9] <- colSums(z[-c(m:n), ])  # OVA_FIN[ ,r ]
         ALL[, r, 10] <- colSums(z[m:n, ])  # MVA_FIN[ ,r ]
     }

--- a/R/wwz.R
+++ b/R/wwz.R
@@ -62,14 +62,14 @@ wwz <- function(x) {
     ## all Terms are numbered as in Table A2 in the Appendix of WWZ
     ## 
 
-    
+    Vhat.diag <- diag(x$Vhat)
+
     ## 
     ## DVA_FIN
     ##
     start <- Sys.time()
 
     ## Term 1
-    Vhat.diag <- diag(x$Vhat)
     Bd_Vhat <- x$Bd * Vhat.diag
     for (r in 1:x$G) {
         Ym.country <- x$Ym[, r]
@@ -77,6 +77,7 @@ wwz <- function(x) {
     }
     elapsed <- round(Sys.time() - start, digits = 3)
     message("1/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
 
     
     ## 
@@ -91,7 +92,9 @@ wwz <- function(x) {
     for (r in 1:x$G) {
         ALL[, r, 2] <- VsLss.colSums * t(Am_Bd_Yd[, r])
     }
-    message("2/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("2/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
 
 
 
@@ -122,7 +125,9 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 3] <- VsLss.colSums * (rowSums(z3[, m:n]))
     }
-    message("3/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("3/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
     
     
     ## Term 4
@@ -141,7 +146,9 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 4] <- VsLss.colSums * (rowSums(z2[, m:n]))
     }
-    message("4/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("4/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
     
     
     ## Term 5
@@ -158,7 +165,9 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 5] <- VsLss.colSums * (rowSums(z2[, m:n]))
     }
-    message("5/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("5/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
 
     
 
@@ -182,7 +191,9 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 6] <- VsLss.colSums * (rowSums(z1[, m:n]))
     }
-    message("6/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("6/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
     
     
     ## Term 7
@@ -199,7 +210,9 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 7] <- VsLss.colSums * (rowSums(z1[, m:n]))
     }
-    message("7/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("7/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
 
     
     
@@ -217,7 +230,9 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 8] <- VsLss.colSums * (rowSums(z2[, m:n]))
     }
-    message("8/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("8/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
     
     
 
@@ -239,7 +254,9 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 13] <- VsLss.colSums * (rowSums(z1[, m:n]))
     }
-    message("9/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("9/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
 
     
     ## Part 2-10 == H10-(10): DDC_INT
@@ -251,7 +268,9 @@ wwz <- function(x) {
         n <- x$N + (r - 1) * x$N
         ALL[, r, 14] <- Vc_Bd_VsLss.colsums * (rowSums(Am_X[, m:n]))
     }
-    message("10/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("10/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
     
     ## Part 2-11 == H10-(11): MVA_FIN =[ VrBrs#Ysr ] H10-(14): OVA_FIN =[
     ## Sum(VtBts)#rYsr ] OK !
@@ -265,7 +284,9 @@ wwz <- function(x) {
         ALL[, r, 9] <- colSums(z[-c(m:n), ])  # OVA_FIN[ ,r ]
         ALL[, r, 10] <- colSums(z[m:n, ])  # MVA_FIN[ ,r ]
     }
-    message("12/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("12/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
 
     ## 
     ## MVA_FIN
@@ -274,30 +295,48 @@ wwz <- function(x) {
     ## Part 2-12 == H10-(12):
     ## MVA_INT =[ VrBrs#AsrLrrYrr ] H10-(15): OVA_INT =[
     ## Sum(VtBts)#AsrLrrYrr ] OK !
+
     YYrr <- matrix(0, nrow = x$GN, ncol = x$GN)
     Am_L <- x$Am %*% x$L
     for (r in 1:x$G) {
         m <- 1 + (r - 1) * x$N
         n <- x$N + (r - 1) * x$N
-        YYrr[, 1:x$GN] <- x$Yd[, r]
-        z <- VrBrs * t(Am_L %*% YYrr)        
+
+        ## message("r: ", r, "  --> m: ", m, "  n: ", n)
+        ## YYrr[, 1:x$GN] <- x$Yd[, r]
+        ## z <- VrBrs * t(Am_L %*% YYrr)
+        
+        ## better is:
+        zz <- rowSums(sweep(Am_L, 2, x$Yd[, r], `*`))
+        z <- sweep(VrBrs, 2, zz, `*`)
+                
         ALL[, r, 11] <- colSums(z[-c(m:n), ])  #   OVA_INT[ ,r ]
         ALL[, r, 12] <- colSums(z[m:n, ])  #  MVA_INT[ ,r ]
     }
-    message("14/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("14/16, elapsed time: ", elapsed, " seconds")
+    start <- Sys.time()
     
     ## Part 2-13 == H10-(13): MDC
     ## =[ VrBrs#AsrLrrEr* ] == H10-(16): ODC =[ Sum(VtBts)#AsrLrrEr* ] OK !
     for (r in 1:x$G) {
         m <- 1 + (r - 1) * x$N
         n <- x$N + (r - 1) * x$N
-        EEr <- matrix(0, nrow = x$GN, ncol = x$GN)
-        EEr[m:n, 1:x$GN] <- x$E[m:n, 1]
-        z <- VrBrs * t(Am_L %*% EEr)
+
+        ## EEr <- matrix(0, nrow = x$GN, ncol = x$GN)
+        ## EEr[m:n, 1:x$GN] <- x$E[m:n, 1]
+        ## z <- VrBrs * t(Am_L %*% EEr)
+
+        Er <- rep(0, x$GN)
+        Er[m:n] <- x$E[m:n, 1]
+        zz <- rowSums(sweep(Am_L, 2, Er, `*`))
+        z <- sweep(VrBrs, 2, zz, `*`)
+
         ALL[, r, 15] <- colSums(z[-c(m:n), ])  # ODC[ ,r ]
         ALL[, r, 16] <- colSums(z[m:n, ])  # MDC[ ,r ]
     }
-    message("16/16")
+    elapsed <- round(Sys.time() - start, digits = 3)
+    message("16/16, elapsed time: ", elapsed, " seconds")
 
     
     

--- a/R/wwz.R
+++ b/R/wwz.R
@@ -24,15 +24,41 @@
 #' # run the WWZ decomposition on the decompr object
 #' wwz(decompr_object)
 
+library(haven)
+library(decompr)
+library(microbenchmark)
+path <- "W:/00_POOL/02 PROJECT PIPELINE/UNIDO - Global Value Chains and International Cooperation/data/OECD_ICIO/IOtables"
 
-wwz <- function( x ) {
-  
-  # Part 1: Decomposing Export into VA( 16 items )
-  # defining ALL to contain all decomposed results
-  ALL  <- array( 0, dim=c( x$GN, x$G, 19 ) )
-  
-  # the order of 16 items and exp, expint, expfd
-  decomp19 <- c(  "DVA_FIN",
+setwd(path)
+(file <- list.files(pattern = "STATA12.dta$")[1])
+tab <- as.data.table(read_dta(file))
+
+Amat <- as.matrix(tab[grepl("^v", column_names), .SD, .SDcols = colnames(tab)[grepl("^v", 
+    colnames(tab))]])
+FD <- as.matrix(tab[grepl("^v", column_names), .SD, .SDcols = colnames(tab)[grepl("^zfd.+hc$", 
+    colnames(tab))]])
+countries <- unique(substring(colnames(FD), 5, 7))
+industries <- unique(substring(colnames(Amat)[1:100], 7, 100))
+output <- unlist(tab[column_names == "zzz_OUT", .SD, .SDcols = colnames(tab)[grepl("^v", 
+    colnames(tab))], drop = TRUE])
+
+x <- load_tables_vectors(Amat, FD, countries, industries, output)
+
+hd <- function(x) x[1:10, 1:10]
+test <- function(x1, x2) {
+    dimnames(x1) <- NULL
+    dimnames(x2) <- NULL
+    identical(x1, x2)
+}
+
+wwz <- function(x) {
+    
+    ## Part 1: Decomposing Export into VA( 16 items ) defining ALL to
+    ## contain all decomposed results
+    ALL <- array(0, dim = c(x$GN, x$G, 19))
+    
+    ## the order of 16 items and exp, expint, expfd
+    decomp19 <- c("DVA_FIN",
                   "DVA_INT",
                   "DVA_INTrexI1",
                   "DVA_INTrexF",
@@ -50,300 +76,312 @@ wwz <- function( x ) {
                   "MDC",
                   "texp",
                   "texpint",
-                  "texpfd"
-  )
-  
-  ALL[ ,,17 ] <- x$ESR
-  ALL[ ,,18 ] <- x$Eint
-  ALL[ ,,19 ] <- x$Efd
-  x$Eint      <- NULL
-  x$Efd       <- NULL
-  
-  
-  ####### THIS ONE TAKES A LONG TIME ##########
-  # Part 2-1 == H10-(1): DVA_FIN=[ VsBss#Ysr ]
-  # OK
-  for ( r in 1: x$G ) {
-    z1           <- matrix( x$Ym[ , r], nrow = x$GN, ncol = x$GN )
-    ALL[ ,r,1 ]  <- colSums( x$Vhat %*% x$Bd * t(z1) )
-  }
-  # View( ALL[ ,,1 ] )   # DVA_FIN
-  
-  
-  # Part 2-2: H10-(2): DVA_INT
-  # OK
-  VsLss <- x$Vhat %*% x$L
-  z1    <- x$Am %*% x$Bd %*% x$Yd
-  for ( r in 1: x$G ) {
-    # r=2
-    ALL[ ,r,2 ] <- colSums(VsLss)*t(z1[ ,r ])
-  }
-  # View( ALL[ ,,2 ] )   #  DVA_INT
-  
-  
-  # Part 2-3: H10-(3): DVA_INTrexI1
-  # OK
-  z1 <- matrix(rowSums( x$Yd), nrow = x$GN, ncol = x$GN )
-  for ( tt in 1:x$G ) {
-    m <- 1   + (tt-1) * x$N
-    n <- x$N + (tt-1) * x$N
-    z1[ m:n,m:n ] <- 0
-  }
-  
-  z2 <- x$Bm %*% z1
-  for ( tt in 1:x$G ) {
-    m <- 1   + (tt-1) * x$N
-    n <- x$N + (tt-1) * x$N
-    z2[ m:n,m:n ] <- 0
-  }
-  
-  z3 <- x$Am * t( z2 )
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    ALL[ ,r,3 ] <- colSums(VsLss) * (rowSums(z3[ ,m:n ]) )
-  }
-  # View( ALL[ ,,3 ] )  #  DVA_INTrexI1
-  
-  
-  # Part 2-4: H10-(4): DVA_INTrexF
-  # OK
-  z <- matrix( 0, nrow = x$GN, ncol = x$GN )
-  z1 <- rowSums( x$Ym )
-  for ( tt in 1:x$G ){
-    m <- 1   + (tt-1) * x$N
-    n <- x$N + (tt-1) * x$N
-    z[,m:n]      <- z1 - x$Ym[ ,tt ]
-    z[ m:n,m:n ] <- 0
-  }
-  
-  z2 <- x$Am * t(x$Bd %*% z)
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    ALL[ ,r,4 ] <- colSums(VsLss) * (rowSums(z2[ ,m:n ]) )
-  }
+                  "texpfd")
+    
+    ALL[, , 17] <- x$ESR
+    ALL[, , 18] <- x$Eint
+    ALL[, , 19] <- x$Efd
+    x$Eint <- NULL
+    x$Efd <- NULL
 
-  
-  # Part 2-5: H10-(5): DVA_INTrexI2
-  # OK !
-  z1 <- t( x$Bm %*% z )
-  for ( tt in 1:x$G ){
-    m <- 1   + (tt-1) * x$N
-    n <- x$N + (tt-1) * x$N
-    z1[ m:n,m:n ] <- 0
-  }
-  
-  z2 <- x$Am * z1
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    ALL[ ,r,5 ] <- colSums(VsLss) * (rowSums(z2[ ,m:n ]) )
-  }
-  #  View( ALL[ ,,5 ] )  #  DVA_INTrexI2
-  
-  
-  # Part 2-6: H10-(6): RDV_FIN
-  # OK !
-  z <- matrix( 0, nrow = x$GN, ncol = x$GN )
-  for ( tt in 1:x$G ){
-    m <- 1   + (tt-1) * x$N
-    n <- x$N + (tt-1) * x$N
-    z[,m:n] <-  x$Ym[ ,tt ]
-  }
-  
-  z1 <- x$Am * t( x$Bd %*% z )
 
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    ALL[ ,r,7 ] <- colSums(VsLss) * (rowSums(z1[ ,m:n ]) )
-  }
-  # View( ALL[ ,,7 ] )  #  RDV_FIN
-  
-  
-  # Part 2-7 == H10-(7): RDV_FIN2
-  # OK !
-  z1 <- x$Bm %*% z
-  for ( tt in 1:x$G ){
-    m <- 1   + (tt-1) * x$N
-    n <- x$N + (tt-1) * x$N
-    z1[ m:n,m:n ] <- 0
-  }
-  
-  z2 <- x$Am * t(z1)
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    ALL[ ,r,8 ] <- colSums(VsLss)*(rowSums(z2[ ,m:n ]) )
-  }
-  # rm(z2)
-  # View( ALL[ ,,8 ] )  #  RDV_FIN2
-
-  
-  # Part 2-8 == H10-(8): RDV_INT
-  # OK !
-  z <- matrix( 0, nrow = x$GN, ncol = x$GN )
-  for ( tt in 1:x$G ){
-    m <- 1   + (tt-1) * x$N
-    n <- x$N + (tt-1) * x$N
-    z[,m:n] <-  x$Yd[ ,tt ]
-  }
-  
-  z1 <- x$Am * t( x$Bm %*% z )
-  for ( r in 1: x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    ALL[ ,r,6 ] <- colSums(VsLss)*(rowSums(z1[ ,m:n ]) )
-  }
-  # View( ALL[ ,,6 ] )  #  RDV_INT
-  
-  
-  # Part 2-9 == H10-(9): DDC_FIN
-  # OK !
-  z <- matrix( 0, nrow = x$GN, ncol = x$GN)
-  for ( tt in 1:x$G ){
-    m <- 1   + (tt-1) * x$N
-    n <- x$N + (tt-1) * x$N
-    z[m:n,m:n] <-  rowSums( x$Ym[ m:n, ] )
-  }
-  
-  z1 <- x$Am * t(x$Bm %*% z)
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    ALL[ ,r,13 ] <- colSums(VsLss)*(rowSums(z1[ ,m:n ]))
-  }
-  # View( ALL[ ,,13 ] )  #   DDC_FIN
-  
-
-  ####### THIS ONE TAKES A LONG TIME ##########
-  # Part 2-10 == H10-(10): DDC_INT
-  # OK !
-  z <- x$Am %*% diag(x$X)
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    ALL[ ,r,14 ] <- colSums(diag(x$Vc) %*% x$Bd - VsLss) * (rowSums( z[ ,m:n ]) )
-  }
-  # rm(VsLss)
-  # View( ALL[ ,,14 ] )  # DDC_INT
-  
-  # Part 2-11 == H10-(11): MVA_FIN  =[ VrBrs#Ysr ]
-  #    H10-(14): OVA_FIN  =[ Sum(VtBts)#rYsr ]
-  # OK !
-  VrBrs <- x$Vhat %*% x$Bm
-  YYsr  <- matrix(0, nrow = x$GN, ncol = x$GN)
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    YYsr[ ,1:x$GN ] <- x$Ym[ ,r ]
-    z <- VrBrs * t( YYsr )
-    ALL[ ,r,10 ] <- colSums( z[ m:n, ]       ) # MVA_FIN[ ,r ]
-    ALL[ ,r,9 ]  <- colSums( z[ -c( m:n ), ] ) # OVA_FIN[ ,r ]
-  }
-  # rm( YYsr )
-  # View( ALL[ ,,9 ]  ) # OVA_FIN
-  # View( ALL[ ,,10 ] ) # MVA_FIN
-  
-  ####### THIS ONE TAKES A VERY LONG TIME ##########
-  # Part 2-12 == H10-(12): MVA_INT  =[ VrBrs#AsrLrrYrr ]
-  #     H10-(15): OVA_INT  =[ Sum(VtBts)#AsrLrrYrr ]
-  # OK !
-  YYrr <- matrix(0, nrow = x$GN, ncol = x$GN)
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    YYrr[ , 1:x$GN ] <- x$Yd[ , r ]
-    z <- VrBrs * t(x$Am %*% x$L %*% YYrr)
-    ALL[ ,r,12 ] <- colSums( z[ m:n, ]        )  #  MVA_INT[ ,r ]
-    ALL[ ,r,11 ] <- colSums( z[ -c( m:n ) , ] )  #   OVA_INT[ ,r ]
-  }
-  # rm( YYrr )
-  # View( ALL[ ,,11 ] )  #  OVA_INT
-  # View( ALL[ ,,12 ] )  #  MVA_INT
-  
-  ####### THIS ONE TAKES A VERY LONG TIME ##########
-  # Part 2-13 == H10-(13): MDC  =[ VrBrs#AsrLrrEr* ]
-  # ==  H10-(16): ODC  =[ Sum(VtBts)#AsrLrrEr* ]
-  # OK !
-  for ( r in 1:x$G ) {
-    m <- 1   + (r-1) * x$N
-    n <- x$N + (r-1) * x$N
-    EEr <- matrix(0, nrow = x$GN, ncol = x$GN)
-    EEr[ m:n, 1:x$GN ] <- x$E[ m:n, 1 ]
-    z <- VrBrs * t(x$Am %*% x$L %*% EEr)
-    ALL[ ,r,16 ] <- colSums( z[ m:n, ]        )   # MDC[ ,r ]
-    ALL[ ,r,15 ] <- colSums( z[ -c( m:n ) , ] )   # ODC[ ,r ]
-  }
-  # rm( EEr, z, VrBrs )
-  
-  
-  ###### try to calculate DViX_Fsr
-  DViX_Fsr <- VsLss %*% x$ESR
-  DViX_Fsr <- t(DViX_Fsr)
-  dim(DViX_Fsr) <- c(x$GN*x$G, 1)
-  
-  
-  dimnames( ALL )  <-  list( x$rownam, x$k, decomp19)  
-  
-  
-  # Part 3 Putting all results in one sheet
-  
-  for ( u in 1:x$GN ){
-    if ( u==1 ){
-      #ALLandTotal <- rbind( ALL[ u,, ], colSums( ALL[ u,, ] ))
-      ALLandTotal <- rbind( ALL[ u,, ])
+    
+    ## 
+    ## DVA_FIN
+    ## 
+    Vhat.diag <- diag(x$Vhat)
+    Bd_Vhat <- x$Bd * Vhat.diag
+    for (r in 1:x$G) {
+        Ym.country <- x$Ym[, r]
+        ALL[, r, 1] <- colSums(sweep(Bd_Vhat, 2, Ym.country, `*`))
     }
-    else {
-      #ALLandTotal <- rbind( ALLandTotal, ALL[ u,, ], colSums( ALL[ u,, ] ))
-      ALLandTotal <- rbind( ALLandTotal, ALL[ u,, ])
-    }
-  }
-  # rm(ALL)
-  rownames( ALLandTotal ) <- NULL #x$bigrownam
-  
-  
-  
-  # Part 4  checking the differences resulted in texp, texpfd, texpintdiff
-  
-  texpdiff        <- rowSums( ALLandTotal[ ,1:16 ]) - ALLandTotal[ ,17 ]
-  
-  texpfddiff      <- ALLandTotal[ ,1] + ALLandTotal[ ,9 ] + ALLandTotal[ ,10 ] - ALLandTotal[ ,19 ]
+    
+    ## was:
+    ## for ( r in 1: x$G ) { z1 <- matrix( x$Ym[ , r], nrow = x$GN,
+    ## ncol = x$GN ) ALL[, r, 1] <- colSums( x$Vhat %*% x$Bd * t(z1) ) }
+    ## View( ALL[ ,,1 ] ) # DVA_FIN
 
-  texpintdiff     <- rowSums( ALLandTotal[ ,2:8 ] ) + rowSums( ALLandTotal[ ,11:16 ] ) - ALLandTotal[ ,18 ]
-  
-  texpdiffpercent <-  texpdiff / ALLandTotal[ ,17 ] * 100
-  texpdiffpercent[ is.na(texpdiffpercent) ] <- 0
-  texpfddiffpercent <-  texpfddiff/ALLandTotal[ ,19 ] * 100
-  texpfddiffpercent[ is.na(texpfddiffpercent) ] <- 0
-  texpintdiffpercent <-  texpintdiff/ALLandTotal[ ,18 ] * 100
-  texpintdiffpercent[ is.na(texpintdiffpercent) ] <- 0
-  texpdiff <- round( texpdiff, 4)
-  texpfddiff <- round( texpfddiff,4)
-  texpintdiff <-  round( texpintdiff, 4)
-  texpdiffpercent <- round( texpdiffpercent, 4)
-  texpfddiffpercent <- round( texpfddiffpercent,4)
-  texpintdiffpercent <-  round( texpintdiffpercent, 4)
-  
-  ALLandTotal <-   data.frame( rep(x$k,                       each=length(x$k)*length(x$i) ),
-                               rep(x$i,  times = length(x$k), each=length(x$k) ),
-                               rep(x$k,  times = length(x$k)*length(x$i) ),
-                               ALLandTotal,
-                               texpdiff,
-                               texpfddiff,
-                               texpintdiff,
-                               texpdiffpercent,
-                               texpfddiffpercent,
-                               texpintdiffpercent,
-                               DViX_Fsr)
-  
-  names(ALLandTotal)[1:3] <- c("Exporting_Country", "Exporting_Industry", "Importing_Country")
-                          
-  # dim( ALLandTotal )
-  
-  attr(ALLandTotal, "decomposition") <- "wwz"
-  
-  return(ALLandTotal)
-  
+
+    
+    ## 
+    ## DVA_INT
+    ## 
+
+    ## VsLss.1 <- x$Vhat %*% x$L
+    VsLss <- Vhat.diag * x$L
+    VsLss.colsums <- colSums(VsLss)
+    Am_Bd_Yd <- x$Am %*% x$Bd %*% x$Yd
+    
+    for (r in 1:x$G) {
+        ALL[, r, 2] <- VsLss.colsums * t(Am_Bd_Yd[, r])
+    }
+    ## View( ALL[ ,,2 ] ) # DVA_INT
+
+
+
+    ##
+    ## DVA_INTrex
+    ## 
+
+    ## not yet enhanced {{{
+    
+    ## Part 2-3: H10-(3): DVA_INTrexI1 OK
+    z1 <- matrix(rowSums(x$Yd), nrow = x$GN, ncol = x$GN)
+    for (tt in 1:x$G) {
+        m <- 1 + (tt - 1) * x$N
+        n <- x$N + (tt - 1) * x$N
+        z1[m:n, m:n] <- 0
+    }
+    
+    z2 <- x$Bm %*% z1
+    for (tt in 1:x$G) {
+        m <- 1 + (tt - 1) * x$N
+        n <- x$N + (tt - 1) * x$N
+        z2[m:n, m:n] <- 0
+    }
+    
+    z3 <- x$Am * t(z2)
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        ALL[, r, 3] <- colSums(VsLss) * (rowSums(z3[, m:n]))
+    }
+    ## View( ALL[ ,,3 ] ) # DVA_INTrexI1
+    
+    
+    ## Part 2-4: H10-(4): DVA_INTrexF OK
+    z <- matrix(0, nrow = x$GN, ncol = x$GN)
+    z1 <- rowSums(x$Ym)
+    for (tt in 1:x$G) {
+        m <- 1 + (tt - 1) * x$N
+        n <- x$N + (tt - 1) * x$N
+        z[, m:n] <- z1 - x$Ym[, tt]
+        z[m:n, m:n] <- 0
+    }
+    
+    z2 <- x$Am * t(x$Bd %*% z)
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        ALL[, r, 4] <- colSums(VsLss) * (rowSums(z2[, m:n]))
+    }
+    
+    
+    ## Part 2-5: H10-(5): DVA_INTrexI2 OK !
+    z1 <- t(x$Bm %*% z)
+    for (tt in 1:x$G) {
+        m <- 1 + (tt - 1) * x$N
+        n <- x$N + (tt - 1) * x$N
+        z1[m:n, m:n] <- 0
+    }
+    
+    z2 <- x$Am * z1
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        ALL[, r, 5] <- colSums(VsLss) * (rowSums(z2[, m:n]))
+    }
+    ## View( ALL[ ,,5 ] ) # DVA_INTrexI2
+    
+    
+    ## Part 2-6: H10-(6): RDV_FIN OK !
+    z <- matrix(0, nrow = x$GN, ncol = x$GN)
+    for (tt in 1:x$G) {
+        m <- 1 + (tt - 1) * x$N
+        n <- x$N + (tt - 1) * x$N
+        z[, m:n] <- x$Ym[, tt]
+    }
+    
+    z1 <- x$Am * t(x$Bd %*% z)
+    
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        ALL[, r, 7] <- colSums(VsLss) * (rowSums(z1[, m:n]))
+    }
+    ## View( ALL[ ,,7 ] ) # RDV_FIN
+    
+    
+    ## Part 2-7 == H10-(7): RDV_FIN2 OK !
+    z1 <- x$Bm %*% z
+    for (tt in 1:x$G) {
+        m <- 1 + (tt - 1) * x$N
+        n <- x$N + (tt - 1) * x$N
+        z1[m:n, m:n] <- 0
+    }
+    
+    z2 <- x$Am * t(z1)
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        ALL[, r, 8] <- colSums(VsLss) * (rowSums(z2[, m:n]))
+    }
+    ## rm(z2) View( ALL[ ,,8 ] ) # RDV_FIN2
+    
+    
+    ## Part 2-8 == H10-(8): RDV_INT OK !
+    z <- matrix(0, nrow = x$GN, ncol = x$GN)
+    for (tt in 1:x$G) {
+        m <- 1 + (tt - 1) * x$N
+        n <- x$N + (tt - 1) * x$N
+        z[, m:n] <- x$Yd[, tt]
+    }
+    
+    z1 <- x$Am * t(x$Bm %*% z)
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        ALL[, r, 6] <- colSums(VsLss) * (rowSums(z1[, m:n]))
+    }
+    ## View( ALL[ ,,6 ] ) # RDV_INT
+
+    ## }}}
+    
+    
+
+    ##
+    ## DDC
+    ## 
+
+    ## Part 2-9 == H10-(9): DDC_FIN OK !
+    z <- matrix(0, nrow = x$GN, ncol = x$GN)
+    for (tt in 1:x$G) {
+        m <- 1 + (tt - 1) * x$N
+        n <- x$N + (tt - 1) * x$N
+        z[m:n, m:n] <- rowSums(x$Ym[m:n, ])
+    }
+    
+    z1 <- x$Am * t(x$Bm %*% z)
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        ALL[, r, 13] <- colSums(VsLss) * (rowSums(z1[, m:n]))
+    }
+    ## View( ALL[ ,,13 ] ) # DDC_FIN
+
+    
+    ## Part 2-10 == H10-(10): DDC_INT
+
+    ## z.1 <- x$Am %*% diag(x$X)
+    Am_X <- t(t(x$Am) * x$X)
+    Vc_Bd_VsLss.colsums <- colSums((x$Vc * x$Bd) - VsLss)    
+    
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        ## message("m: ", m, "  n: ", n)
+        ALL[, r, 14] <- Vc_Bd_VsLss.colsums * (rowSums(Am_X[, m:n]))
+    }
+
+    stop("stopped here")
+    
+    ## Part 2-11 == H10-(11): MVA_FIN =[ VrBrs#Ysr ] H10-(14): OVA_FIN =[
+    ## Sum(VtBts)#rYsr ] OK !
+    VrBrs <- x$Vhat %*% x$Bm
+    YYsr <- matrix(0, nrow = x$GN, ncol = x$GN)
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        YYsr[, 1:x$GN] <- x$Ym[, r]
+        z <- VrBrs * t(YYsr)
+        ALL[, r, 10] <- colSums(z[m:n, ])  # MVA_FIN[ ,r ]
+        ALL[, r, 9] <- colSums(z[-c(m:n), ])  # OVA_FIN[ ,r ]
+    }
+    ## rm( YYsr ) View( ALL[ ,,9 ] ) # OVA_FIN View( ALL[ ,,10 ] )
+
+    ## 
+    ## MVA_FIN
+    ## 
+    
+    ####### THIS ONE TAKES A VERY LONG TIME ########## Part 2-12 == H10-(12):
+    ####### MVA_INT =[ VrBrs#AsrLrrYrr ] H10-(15): OVA_INT =[
+    ####### Sum(VtBts)#AsrLrrYrr ] OK !
+    YYrr <- matrix(0, nrow = x$GN, ncol = x$GN)
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        YYrr[, 1:x$GN] <- x$Yd[, r]
+        z <- VrBrs * t(x$Am %*% x$L %*% YYrr)
+        ALL[, r, 12] <- colSums(z[m:n, ])  #  MVA_INT[ ,r ]
+        ALL[, r, 11] <- colSums(z[-c(m:n), ])  #   OVA_INT[ ,r ]
+    }
+    ## rm( YYrr ) View( ALL[ ,,11 ] ) # OVA_INT View( ALL[ ,,12 ] ) #
+    ## MVA_INT
+    
+    ####### THIS ONE TAKES A VERY LONG TIME ########## Part 2-13 == H10-(13): MDC
+    ####### =[ VrBrs#AsrLrrEr* ] == H10-(16): ODC =[ Sum(VtBts)#AsrLrrEr* ] OK !
+    for (r in 1:x$G) {
+        m <- 1 + (r - 1) * x$N
+        n <- x$N + (r - 1) * x$N
+        EEr <- matrix(0, nrow = x$GN, ncol = x$GN)
+        EEr[m:n, 1:x$GN] <- x$E[m:n, 1]
+        z <- VrBrs * t(x$Am %*% x$L %*% EEr)
+        ALL[, r, 16] <- colSums(z[m:n, ])  # MDC[ ,r ]
+        ALL[, r, 15] <- colSums(z[-c(m:n), ])  # ODC[ ,r ]
+    }
+    ## rm( EEr, z, VrBrs )
+    
+    
+    ###### try to calculate DViX_Fsr
+    DViX_Fsr <- VsLss %*% x$ESR
+    DViX_Fsr <- t(DViX_Fsr)
+    dim(DViX_Fsr) <- c(x$GN * x$G, 1)
+    
+    
+    dimnames(ALL) <- list(x$rownam, x$k, decomp19)
+    
+    
+    ## Part 3
+    ## Putting all results in one sheet
+    for (u in 1:x$GN) {
+        if (u == 1) {
+            ## ALLandTotal <- rbind( ALL[ u,, ], colSums( ALL[ u,, ] ))
+            ALLandTotal <- rbind(ALL[u, , ])
+        } else {
+            ## ALLandTotal <- rbind( ALLandTotal, ALL[ u,, ], colSums( ALL[ u,, ] ))
+            ALLandTotal <- rbind(ALLandTotal, ALL[u, , ])
+        }
+    }
+    ## rm(ALL)
+    rownames(ALLandTotal) <- NULL  #x$bigrownam
+    
+    
+    
+    ## Part 4 checking the differences resulted in texp, texpfd, texpintdiff
+    
+    texpdiff <- rowSums(ALLandTotal[, 1:16]) - ALLandTotal[, 17]
+    
+    texpfddiff <- ALLandTotal[, 1] + ALLandTotal[, 9] + ALLandTotal[, 10] - 
+        ALLandTotal[, 19]
+    
+    texpintdiff <- rowSums(ALLandTotal[, 2:8]) + rowSums(ALLandTotal[, 
+        11:16]) - ALLandTotal[, 18]
+    
+    texpdiffpercent <- texpdiff/ALLandTotal[, 17] * 100
+    texpdiffpercent[is.na(texpdiffpercent)] <- 0
+    texpfddiffpercent <- texpfddiff/ALLandTotal[, 19] * 100
+    texpfddiffpercent[is.na(texpfddiffpercent)] <- 0
+    texpintdiffpercent <- texpintdiff/ALLandTotal[, 18] * 100
+    texpintdiffpercent[is.na(texpintdiffpercent)] <- 0
+    texpdiff <- round(texpdiff, 4)
+    texpfddiff <- round(texpfddiff, 4)
+    texpintdiff <- round(texpintdiff, 4)
+    texpdiffpercent <- round(texpdiffpercent, 4)
+    texpfddiffpercent <- round(texpfddiffpercent, 4)
+    texpintdiffpercent <- round(texpintdiffpercent, 4)
+    
+    ALLandTotal <- data.frame(rep(x$k, each = length(x$k) * length(x$i)), 
+        rep(x$i, times = length(x$k), each = length(x$k)), rep(x$k, times = length(x$k) * 
+            length(x$i)), ALLandTotal, texpdiff, texpfddiff, texpintdiff, 
+        texpdiffpercent, texpfddiffpercent, texpintdiffpercent, DViX_Fsr)
+    
+    names(ALLandTotal)[1:3] <- c("Exporting_Country", "Exporting_Industry", 
+        "Importing_Country")
+    
+    ## dim( ALLandTotal )
+    
+    attr(ALLandTotal, "decomposition") <- "wwz"
+    
+    return(ALLandTotal)
+    
 }

--- a/man/decomp.Rd
+++ b/man/decomp.Rd
@@ -25,13 +25,13 @@ and second row which contains the five decomposed final demands (M).
 
 \item{o}{vector of final outputs}
 
+\item{v}{vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption}
+
 \item{method}{user specified the decomposition method}
 
 \item{verbose}{logical, should timings of the calculation be displayed? Default is FALSE}
 
 \item{...}{arguments to pass on the respective decomposition method}
-
-\item{V}{vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption}
 }
 \value{
 The output when using the WWZ algorithm is a matrix with dimensions GNG*19.

--- a/man/decomp.Rd
+++ b/man/decomp.Rd
@@ -4,7 +4,7 @@
 \alias{decomp}
 \title{Interface function for decompositions}
 \usage{
-decomp(x, y, k, i, o, method = c("leontief", "wwz"), ...)
+decomp(x, y, k, i, o, V, method = c("leontief", "wwz"), ...)
 }
 \arguments{
 \item{x}{intermediate demand table, it has dimensions GN x GN (G = no. of country, N = no. of industries),
@@ -23,6 +23,8 @@ and second row which contains the five decomposed final demands (M).
 \item{i}{vector of sector or industry names}
 
 \item{o}{vector of final outputs}
+
+\item{V}{vector of value added}
 
 \item{method}{user specified the decomposition method}
 

--- a/man/decomp.Rd
+++ b/man/decomp.Rd
@@ -4,7 +4,8 @@
 \alias{decomp}
 \title{Interface function for decompositions}
 \usage{
-decomp(x, y, k, i, o, V, method = c("leontief", "wwz"), ...)
+decomp(x, y, k, i, o, v, method = c("leontief", "wwz"), verbose = FALSE,
+  ...)
 }
 \arguments{
 \item{x}{intermediate demand table, it has dimensions GN x GN (G = no. of country, N = no. of industries),
@@ -24,11 +25,13 @@ and second row which contains the five decomposed final demands (M).
 
 \item{o}{vector of final outputs}
 
-\item{V}{vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption}
-
 \item{method}{user specified the decomposition method}
 
+\item{verbose}{logical, should timings of the calculation be displayed? Default is FALSE}
+
 \item{...}{arguments to pass on the respective decomposition method}
+
+\item{V}{vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption}
 }
 \value{
 The output when using the WWZ algorithm is a matrix with dimensions GNG*19.

--- a/man/decomp.Rd
+++ b/man/decomp.Rd
@@ -24,7 +24,7 @@ and second row which contains the five decomposed final demands (M).
 
 \item{o}{vector of final outputs}
 
-\item{V}{vector of value added}
+\item{V}{vector of value added, optional. If this vector is not specified, value added will be calculated as gross output - intermediate consumption}
 
 \item{method}{user specified the decomposition method}
 

--- a/man/leontief.Rd
+++ b/man/leontief.Rd
@@ -21,17 +21,17 @@ a data frame containing the square matrix and labelled column and rows
 Leontief Decomposition
 }
 \examples{
-# load example data
+## load example data
 data(leather)
 
-# create intermediate object (class decompr)
+## create intermediate object (class decompr)
 decompr_object <- load_tables_vectors(inter,
                                       final,
                                       countries,
                                       industries,
                                       out        )
 
-# run the Leontief decomposition on the decompr object
+## run the Leontief decomposition on the decompr object
 leontief(decompr_object )
 }
 \author{

--- a/man/load_tables_vectors.Rd
+++ b/man/load_tables_vectors.Rd
@@ -4,7 +4,7 @@
 \alias{load_tables_vectors}
 \title{Load the Input-Output and Final demand tables}
 \usage{
-load_tables_vectors(x, y, k, i, o, V, null_inventory = FALSE)
+load_tables_vectors(x, y, k, i, o, v = NULL, null_inventory = FALSE)
 }
 \arguments{
 \item{x}{intermediate demand table, it has dimensions GN x GN (G = no. of country, N = no. of industries),
@@ -24,7 +24,7 @@ and second row which contains the five decomposed final demands (M).
 
 \item{o}{vector of final outputs}
 
-\item{V}{vector of value added}
+\item{v}{vector of value added}
 
 \item{null_inventory}{when the inventory (last FDC) should be set to zero}
 }
@@ -47,7 +47,7 @@ decompr_object <- load_tables_vectors(inter,
                                       final,
                                       countries,
                                       industries,
-                                      out        )
+                                      out)
 
 # examine output object                                    
 str(decompr_object)

--- a/man/load_tables_vectors.Rd
+++ b/man/load_tables_vectors.Rd
@@ -4,7 +4,7 @@
 \alias{load_tables_vectors}
 \title{Load the Input-Output and Final demand tables}
 \usage{
-load_tables_vectors(x, y, k, i, o, null_inventory = FALSE)
+load_tables_vectors(x, y, k, i, o, V, null_inventory = FALSE)
 }
 \arguments{
 \item{x}{intermediate demand table, it has dimensions GN x GN (G = no. of country, N = no. of industries),
@@ -23,6 +23,8 @@ and second row which contains the five decomposed final demands (M).
 \item{i}{vector of sector or industry names}
 
 \item{o}{vector of final outputs}
+
+\item{V}{vector of value added}
 
 \item{null_inventory}{when the inventory (last FDC) should be set to zero}
 }

--- a/man/wwz.Rd
+++ b/man/wwz.Rd
@@ -4,10 +4,12 @@
 \alias{wwz}
 \title{Runs the Wang-Wei-Zhu decomposition}
 \usage{
-wwz(x)
+wwz(x, verbose = FALSE)
 }
 \arguments{
 \item{x}{an object of the class decompr}
+
+\item{verbose}{logical, should timings of the calculation be displayed? Default is FALSE}
 }
 \value{
 the decomposed table


### PR DESCRIPTION
Hey all,

I found some performance improvements around the calculation of the WWZ-decomposition. Some calculations can be done outside of a loop and some matrix multiplications can be replaced by vector * matrix operations which are a lot faster.

I also added two new options to the decomp-function:
- v: you can now specify the value-added vector yourself (if you are only interested in the value-added the manufacturing sectors create, then you could set the service sectors to 0). If you don't specify it (the default), then the value-added vector will be handled as before. 
- verbose: (default = FALSE) If TRUE, will output timings of each of the 16 parts of the decomposition. Mainly meant for developing purposes.

Kind greetings,
Oliver